### PR TITLE
Cleanup test bound gems from runtime environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 ## Installation
 
-    gem install pipedrive-ruby
+Put it on your `Gemfile`:
+
+    gem 'pipedrive-ruby', git: 'https://github.com/ContaBoa/pipedrive-ruby.git'
 
 ## Usage
 

--- a/pipedrive-ruby.gemspec
+++ b/pipedrive-ruby.gemspec
@@ -74,8 +74,8 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<httparty>, [">= 0"])
       s.add_runtime_dependency(%q<json>, [">= 1.7.7"])
       s.add_runtime_dependency(%q<multi_xml>, [">= 0.5.2"])
-      s.add_runtime_dependency(%q<webmock>, [">= 0"])
-      s.add_runtime_dependency(%q<coveralls>, [">= 0"])
+      s.add_development_dependency(%q<webmock>, [">= 0"])
+      s.add_development_dependency(%q<coveralls>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
@@ -106,4 +106,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<simplecov>, [">= 0"])
   end
 end
-


### PR DESCRIPTION
I've just moved `webmock` & `coveralls` from `runtime_dependency` to `development_dependency` on the gemspec.

This was adding test gems to the production environment, which breaks my heart. 💔 

Any thoughts?
